### PR TITLE
don't require registration if not forwarding and port sharing disabled

### DIFF
--- a/draft-ietf-masque-quic-proxy.md
+++ b/draft-ietf-masque-quic-proxy.md
@@ -496,10 +496,7 @@ malicious.
 
 A proxy that does not support port sharing, SHOULD send "Proxy-QUIC-Port-Sharing"
 with a value of "?0". Doing so allows clients to stop sending capsules for this
-extension if forwarding mode is also not supported. Clients who send "?1", but do
-not receive any "Proxy-QUIC-Port-Sharing" header in response must assume that port
-sharing may be in effect and MUST continue register connection IDs in order for
-the proxied connection to continue to work.
+extension if forwarding mode is also not supported.
 
 When port sharing is supported and forwarded mode is not, registration of target
 Connection IDs is permitted, but is not required since port sharing only requires


### PR DESCRIPTION
The existing text is contradictory to other text that states that, when forwarding and port sharing are both disabled, we reduce to regular connect-udp behavior. There's no value in registrations if both are disabled. Any future extension that wants to take advantage of registrations can state that it's required.